### PR TITLE
Fix setting "root" option to a sub-directory cause building failure

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = {
 
             articles.push({
               fullTitle: stack.slice(0, article.depth).join(' > '),
-              mtime: fs.statSync(path.join(process.cwd(), article.path)).mtime,
+              mtime: fs.statSync(this.resolve(article.path)).mtime,
               url: encodeURI(article.path.replace(/\.md$/, '.html'))
             })
           }


### PR DESCRIPTION
Hi. I found that this plugin does not work with projects that have their `root` option set to a sub-directory. This is my attempt to fix that.